### PR TITLE
Add XML fixing code.

### DIFF
--- a/rads/config/loader.py
+++ b/rads/config/loader.py
@@ -7,7 +7,7 @@ from appdirs import AppDirs, system  # type: ignore
 from dataclass_builder import MissingFieldError
 
 from ..typing import PathLike
-from ..xml import ParseError, parse, rootless_fixer
+from ..xml import ParseError, parse, rads_fixer
 from .ast import ASTEvaluationError
 from .builders import PreConfigBuilder, SatelliteBuilder
 from .grammar import dataroot_grammar, pre_config_grammar, satellite_grammar
@@ -228,7 +228,7 @@ def get_dataroot(
         env: Dict[str, str] = {}
         for file in config_paths:
             try:
-                ast = dataroot_grammar()(parse(file, fixer=rootless_fixer).down())[0]
+                ast = dataroot_grammar()(parse(file, fixer=rads_fixer).down())[0]
                 ast.eval(env, {})
             except (ParseError, TerminalXMLParseError, ASTEvaluationError) as err:
                 raise _to_config_error(err) from err
@@ -294,7 +294,7 @@ def load_config(
     for file in pre_config.config_files:
         # construct ast
         try:
-            ast = satellite_grammar()(parse(file, fixer=rootless_fixer).down())[0]
+            ast = satellite_grammar()(parse(file, fixer=rads_fixer).down())[0]
         except (ParseError, TerminalXMLParseError) as err:
             raise _to_config_error(err) from err
         # evaluate ast for each satellite
@@ -336,7 +336,7 @@ def _load_preconfig(
     builder = PreConfigBuilder()
     for file in xml_paths:
         try:
-            ast = pre_config_grammar()(parse(file, fixer=rootless_fixer).down())[0]
+            ast = pre_config_grammar()(parse(file, fixer=rads_fixer).down())[0]
             ast.eval(builder, {})
         except (ParseError, TerminalXMLParseError, ASTEvaluationError) as err:
             raise _to_config_error(err) from err

--- a/rads/config/loader.py
+++ b/rads/config/loader.py
@@ -7,7 +7,7 @@ from appdirs import AppDirs, system  # type: ignore
 from dataclass_builder import MissingFieldError
 
 from ..typing import PathLike
-from ..xml import ParseError, parse
+from ..xml import ParseError, parse, rootless_fixer
 from .ast import ASTEvaluationError
 from .builders import PreConfigBuilder, SatelliteBuilder
 from .grammar import dataroot_grammar, pre_config_grammar, satellite_grammar
@@ -228,7 +228,7 @@ def get_dataroot(
         env: Dict[str, str] = {}
         for file in config_paths:
             try:
-                ast = dataroot_grammar()(parse(file, rootless=True).down())[0]
+                ast = dataroot_grammar()(parse(file, fixer=rootless_fixer).down())[0]
                 ast.eval(env, {})
             except (ParseError, TerminalXMLParseError, ASTEvaluationError) as err:
                 raise _to_config_error(err) from err
@@ -294,7 +294,7 @@ def load_config(
     for file in pre_config.config_files:
         # construct ast
         try:
-            ast = satellite_grammar()(parse(file, rootless=True).down())[0]
+            ast = satellite_grammar()(parse(file, fixer=rootless_fixer).down())[0]
         except (ParseError, TerminalXMLParseError) as err:
             raise _to_config_error(err) from err
         # evaluate ast for each satellite
@@ -336,7 +336,7 @@ def _load_preconfig(
     builder = PreConfigBuilder()
     for file in xml_paths:
         try:
-            ast = pre_config_grammar()(parse(file, rootless=True).down())[0]
+            ast = pre_config_grammar()(parse(file, fixer=rootless_fixer).down())[0]
             ast.eval(builder, {})
         except (ParseError, TerminalXMLParseError, ASTEvaluationError) as err:
             raise _to_config_error(err) from err

--- a/rads/xml/__init__.py
+++ b/rads/xml/__init__.py
@@ -14,6 +14,13 @@ except ImportError:
     #  fixed.
     from .etree import Element, ParseError  # type: ignore
 
-from .utility import fromstring, fromstringlist, parse
+from .utility import fromstring, fromstringlist, parse, rootless_fixer
 
-__all__ = ["ParseError", "Element", "parse", "fromstring", "fromstringlist"]
+__all__ = [
+    "ParseError",
+    "Element",
+    "parse",
+    "fromstring",
+    "fromstringlist",
+    "rootless_fixer",
+]

--- a/rads/xml/__init__.py
+++ b/rads/xml/__init__.py
@@ -14,7 +14,7 @@ except ImportError:
     #  fixed.
     from .etree import Element, ParseError  # type: ignore
 
-from .utility import fromstring, fromstringlist, parse, rootless_fixer
+from .utility import fromstring, fromstringlist, parse, rads_fixer, rootless_fixer
 
 __all__ = [
     "ParseError",
@@ -23,4 +23,5 @@ __all__ = [
     "fromstring",
     "fromstringlist",
     "rootless_fixer",
+    "rads_fixer",
 ]

--- a/rads/xml/utility.py
+++ b/rads/xml/utility.py
@@ -19,6 +19,7 @@ __all__ = [
     "parse",
     "fromstring",
     "fromstringlist",
+    "rads_fixer",
     "rootless_fixer",
     "strip_blanklines",
     "strip_comments",
@@ -137,6 +138,34 @@ def fromstringlist(
         if file:
             raise xml.error_with_file(err, file) from err
         raise
+
+
+def rads_fixer(text: str) -> str:
+    """Fix XML problems with the upstream RADS XML configuration.
+
+    This fixer is for problems that will not be fixed upstream or for which the
+    fix has been delayed.  It is primary for making up the difference between
+    the official RADS parser which is very lenient and the PyRADS parser which
+    is very strict.
+
+    Currently, this fixes the following bugs with the RADS config.
+
+    * The RADS XML file does not have a root as dictated by the XML 1.0
+      standard.  This is fixed by adding <__ROOTLESS__> tags around the entire
+      file.  This is the only fix that is considered part of the RADS standard
+      (that is RADS lies about it being XML 1.0).
+    * The RADS MXL file has some instances of `int3` used in the <compress>
+      tag.  This is an invalid type (there is no 3 byte integer) and in the
+      official RADS implementation all invalid types default to `dble`
+      (double).  However, The intended type here is `int4`.  This fix corrects
+      this.
+
+    :param text:
+        RADS XML string to fix.
+    :return:
+        Repaired RADS XML string.
+    """
+    return rootless_fixer(text).replace("int3", "int4")
 
 
 def rootless_fixer(text: str) -> str:

--- a/rads/xml/utility.py
+++ b/rads/xml/utility.py
@@ -55,14 +55,18 @@ def parse(
         The root XML element.  If `rootless` is True this will be the added
         `<rootless>` element
     """
+    filename = filestring(source)
     if fixer:
         with ensure_open(source) as file:
-            return fromstring(
-                file.read(), parser=parser, fixer=fixer, file=filestring(source)
-            )
-    return xml.Element(
-        xml.parse(_fix_source(source), parser).getroot(), file=filestring(source)
-    )
+            return fromstring(file.read(), parser=parser, fixer=fixer, file=filename)
+    try:
+        return xml.Element(
+            xml.parse(_fix_source(source), parser).getroot(), file=filename
+        )
+    except xml.ParseError as err:
+        if filename:
+            raise xml.error_with_file(err, filename) from err
+        raise
 
 
 def fromstring(

--- a/rads/xml/utility.py
+++ b/rads/xml/utility.py
@@ -124,7 +124,7 @@ def fromstringlist(
         The root XML element (of the section given in `text`).  If `rootless`
         is True this will be the added `<rootless>` element.
     """
-    if fixer is None:
+    if fixer is not None:
         return fromstring("\n".join(sequence), parser=parser, fixer=fixer, file=file)
     try:
         return xml.Element(xml.fromstringlist(sequence, parser), file=file)
@@ -142,6 +142,12 @@ def rootless_fixer(text: str) -> str:
     :func:`fromstringlist` to load XML files that do not have a root tag.  This
     is done by adding a <__ROOTLESS__> block around the entire document.
 
+    .. note::
+
+        If the file does not contain any XML tags (only processing instructions
+        and comments) the original text will be returned unchanged in an effort
+        to preserve error handling.
+
     :param text:
         XML text to wrap <__ROOTLESS__> tags around.
     :return:
@@ -149,7 +155,7 @@ def rootless_fixer(text: str) -> str:
         processing instructions).
     """
     if not strip_blanklines(strip_comments(strip_processing_instructions(text))):
-        return ""
+        return text
 
     def is_prolog(text: str) -> bool:
         return text.lstrip().startswith("<?")
@@ -163,6 +169,11 @@ def rootless_fixer(text: str) -> str:
 def strip_comments(text: str) -> str:
     """Remove XML comments from a string.
 
+    .. note::
+
+        This will not remove lines that had comments, it only removes the text
+        from "<!--" to "-->".
+
     :param text:
         XML text to strip comments from.
 
@@ -175,6 +186,11 @@ def strip_comments(text: str) -> str:
 
 def strip_processing_instructions(text: str) -> str:
     """Remove XML processing instructions from a string.
+
+    .. note::
+
+        This will not remove lines that had processing instructions, it only
+        removes the text from "<?" to "?>".
 
     :param text:
         XML text to strip processing instructions from.

--- a/tests/xml/test_utility.py
+++ b/tests/xml/test_utility.py
@@ -1,0 +1,279 @@
+import io
+from textwrap import dedent
+
+import pytest  # type: ignore
+
+from rads.xml import ParseError
+from rads.xml.utility import (
+    fromstring,
+    fromstringlist,
+    parse,
+    rootless_fixer,
+    strip_blanklines,
+    strip_comments,
+    strip_processing_instructions,
+)
+
+
+def test_strip_comments_single_line_comments():
+    xml = """\
+    <!--single line comment!-->
+    <a>Hello World</a>
+    <!--single line comment!-->
+    <a>Goodbye</a>
+    """
+    assert strip_comments(dedent(xml)).splitlines() == [
+        "",
+        "<a>Hello World</a>",
+        "",
+        "<a>Goodbye</a>",
+    ]
+
+
+def test_strip_comments_inline_comments():
+    xml = """\
+    <!--inline comment!-->  <a>Hello World</a> <!--inline comment!-->
+    <a>Goodbye</a>
+    """
+    assert strip_comments(dedent(xml)).splitlines() == [
+        "  <a>Hello World</a> ",
+        "<a>Goodbye</a>",
+    ]
+
+
+def test_strip_comments_multiline_comments():
+    xml = """\
+    <a>Hello World</a>
+    <!--multi
+    line
+    comment--> <a>Goodbye</a> <!--another multi
+    line comment-->
+    """
+    assert strip_comments(dedent(xml)).splitlines() == [
+        "<a>Hello World</a>",
+        " <a>Goodbye</a> ",
+    ]
+
+
+def test_strip_processing_instructions():
+    xml = """\
+    <?xml version="1.0"?>
+    <a>Hello World</a>
+    """
+    assert strip_processing_instructions(dedent(xml)).splitlines() == [
+        "",
+        "<a>Hello World</a>",
+    ]
+
+
+def test_strip_blanklines():
+    xml = """\
+     \t   \t   \t
+    <a>Hello World</a>
+    
+    <a>Goodbye</a>
+    
+    """  # noqa: W293
+    assert strip_blanklines(dedent(xml)).splitlines() == [
+        "<a>Hello World</a>",
+        "<a>Goodbye</a>",
+    ]
+
+
+def test_rootless_fixer():
+    xml = """\
+    <a>Hello World</a>
+    <a>Goodbye</a>
+    """
+    assert rootless_fixer(dedent(xml)).splitlines() == [
+        "<__ROOTLESS__>",
+        "<a>Hello World</a>",
+        "<a>Goodbye</a>",
+        "</__ROOTLESS__>",
+    ]
+
+
+def test_rootless_fixer_with_empty_file():
+    xml = """\
+    <?xml version="1.0"?>
+    <!-- This is an empty rootless XML file-->
+    """
+    assert rootless_fixer(dedent(xml)).splitlines() == dedent(xml).splitlines()
+
+
+# NOTE: A full path file is used below since the API is allowed to expand to a
+#   full path which breaks comparisons.
+
+
+def test_fromstring():
+    xml = """\
+    <message>
+        <sender>John Smith</sender>
+        <content>Hello World</content>
+    </message>
+    """
+    root = fromstring(dedent(xml))
+    assert root.tag == "message"
+    assert root.down().tag == "sender"
+    assert root.down().text == "John Smith"
+    assert root.down().next().tag == "content"
+    assert root.down().next().text == "Hello World"
+
+
+def test_fromstring_with_file():
+    xml = """\
+    <a>Hello World</a>
+    """
+    root = fromstring(dedent(xml), file="/a_file.xml")
+    assert root.file == "/a_file.xml"
+
+
+def test_fromstring_with_empty_xml():
+    # processing instructions and comments do not count as content
+    xml = """\
+    <?xml version="1.0"?>
+    <!--single line comment!-->
+    """
+    with pytest.raises(ParseError):
+        fromstring(dedent(xml))
+
+
+def test_fromstring_with_empty_xml_and_file():
+    # processing instructions and comments do not count as content
+    xml = """\
+    <?xml version="1.0"?>
+    <!--single line comment!-->
+    """
+    with pytest.raises(ParseError) as exc_info:
+        fromstring(dedent(xml), file="/a_file.xml")
+    assert exc_info.value.filename == "/a_file.xml"
+
+
+def test_fromstring_with_fixer():
+    xml = """\
+    <message>
+        <sender>John Smith</sender>
+        <content>Hello World</content>
+    </message>
+    """
+
+    def fixer(text):
+        return text.replace("John Smith", "Nobody").replace("Hello World", "Goodbye")
+
+    root = fromstring(dedent(xml), fixer=fixer)
+    assert root.tag == "message"
+    assert root.down().tag == "sender"
+    assert root.down().text == "Nobody"
+    assert root.down().next().tag == "content"
+    assert root.down().next().text == "Goodbye"
+
+
+def test_fromstringlist():
+    xml = [
+        "<message>",
+        "<sender>John Smith</sender>",
+        "<content>Hello World</content>",
+        "</message>",
+    ]
+    root = fromstringlist(xml)
+    assert root.tag == "message"
+    assert root.down().tag == "sender"
+    assert root.down().text == "John Smith"
+    assert root.down().next().tag == "content"
+    assert root.down().next().text == "Hello World"
+
+
+def test_fromstringlist_with_file():
+    xml = ["<a>Hello World</a>"]
+    root = fromstringlist(xml, file="/a_file.xml")
+    assert root.file == "/a_file.xml"
+
+
+def test_fromstringlist_with_empty_xml():
+    # processing instructions and comments do not count as content
+    xml = ['<?xml version="1.0"?>', "<!--single line comment!-->"]
+    with pytest.raises(ParseError):
+        fromstringlist(xml)
+
+
+def test_fromstringlist_with_empty_xml_and_file():
+    # processing instructions and comments do not count as content
+    xml = ['<?xml version="1.0"?>', "<!--single line comment!-->"]
+    with pytest.raises(ParseError) as exc_info:
+        fromstringlist(xml, file="/a_file.xml")
+    assert exc_info.value.filename == "/a_file.xml"
+
+
+def test_fromstringlist_with_fixer():
+    xml = [
+        "<message>",
+        "<sender>John Smith</sender>",
+        "<content>Hello World</content>",
+        "</message>",
+    ]
+
+    def fixer(text):
+        return text.replace("John Smith", "Nobody").replace("Hello World", "Goodbye")
+
+    root = fromstringlist(xml, fixer=fixer)
+    assert root.tag == "message"
+    assert root.down().tag == "sender"
+    assert root.down().text == "Nobody"
+    assert root.down().next().tag == "content"
+    assert root.down().next().text == "Goodbye"
+
+
+# TODO: Add parse unit tests.
+
+
+def test_parse():
+    xml = """\
+    <message>
+        <sender>John Smith</sender>
+        <content>Hello World</content>
+    </message>
+    """
+    file = io.StringIO(dedent(xml))
+    file.name = "/a_file.xml"
+    root = parse(file)
+    assert root.file == "/a_file.xml"
+    assert root.tag == "message"
+    assert root.down().tag == "sender"
+    assert root.down().text == "John Smith"
+    assert root.down().next().tag == "content"
+    assert root.down().next().text == "Hello World"
+
+
+def test_parse_with_empty_file():
+    # processing instructions and comments do not count as content
+    xml = """\
+    <?xml version="1.0"?>
+    <!--single line comment!-->
+    """
+    file = io.StringIO(dedent(xml))
+    file.name = "/a_file.xml"
+    with pytest.raises(ParseError) as exc_info:
+        parse(file)
+    assert exc_info.value.filename == "/a_file.xml"
+
+
+def test_parse_with_fixer():
+    xml = """\
+    <message>
+        <sender>John Smith</sender>
+        <content>Hello World</content>
+    </message>
+    """
+
+    file = io.StringIO(dedent(xml))
+    file.name = "a_file.xml"
+
+    def fixer(text):
+        return text.replace("John Smith", "Nobody").replace("Hello World", "Goodbye")
+
+    root = parse(file, fixer=fixer)
+    assert root.tag == "message"
+    assert root.down().tag == "sender"
+    assert root.down().text == "Nobody"
+    assert root.down().next().tag == "content"
+    assert root.down().next().text == "Goodbye"

--- a/tests/xml/test_utility.py
+++ b/tests/xml/test_utility.py
@@ -8,6 +8,7 @@ from rads.xml.utility import (
     fromstring,
     fromstringlist,
     parse,
+    rads_fixer,
     rootless_fixer,
     strip_blanklines,
     strip_comments,
@@ -89,6 +90,27 @@ def test_rootless_fixer():
         "<__ROOTLESS__>",
         "<a>Hello World</a>",
         "<a>Goodbye</a>",
+        "</__ROOTLESS__>",
+    ]
+
+
+def test_rads_fixer():
+    xml = """\
+    <?xml version="1.0"?>
+    <!--This is a RADS XML file.-->
+    <var name="range_s">
+        <compress>int3 1e-4</compress>
+    </var>
+    <satellite>ENVISAT1</satellite>
+    """
+    assert rads_fixer(dedent(xml)).splitlines() == [
+        '<?xml version="1.0"?>',
+        "<__ROOTLESS__>",
+        "<!--This is a RADS XML file.-->",
+        '<var name="range_s">',
+        "    <compress>int4 1e-4</compress>",
+        "</var>",
+        "<satellite>ENVISAT1</satellite>",
         "</__ROOTLESS__>",
     ]
 


### PR DESCRIPTION
This adds a fixer before loading the RADS XML.  This allows PyRADS to fix small errors in the upstream RADS configuration file.