### PR TITLE
Don't crash on empty RADS XML files.

### DIFF
--- a/rads/config/loader.py
+++ b/rads/config/loader.py
@@ -232,6 +232,8 @@ def get_dataroot(
                 ast.eval(env, {})
             except (ParseError, TerminalXMLParseError, ASTEvaluationError) as err:
                 raise _to_config_error(err) from err
+            except StopIteration:
+                pass
         try:
             dataroot_ = Path(os.path.expanduser(os.path.expandvars(env["dataroot"])))
         except KeyError:
@@ -297,6 +299,8 @@ def load_config(
             ast = satellite_grammar()(parse(file, fixer=rads_fixer).down())[0]
         except (ParseError, TerminalXMLParseError) as err:
             raise _to_config_error(err) from err
+        except StopIteration:
+            pass
         # evaluate ast for each satellite
         for sat, builder in builders.items():
             try:
@@ -340,6 +344,8 @@ def _load_preconfig(
             ast.eval(builder, {})
         except (ParseError, TerminalXMLParseError, ASTEvaluationError) as err:
             raise _to_config_error(err) from err
+        except StopIteration:
+            pass
     builder.dataroot = dataroot_
     builder.config_files = list(xml_paths)
     try:

--- a/tests/xml/test_utility.py
+++ b/tests/xml/test_utility.py
@@ -81,19 +81,6 @@ def test_strip_blanklines():
     ]
 
 
-def test_rootless_fixer():
-    xml = """\
-    <a>Hello World</a>
-    <a>Goodbye</a>
-    """
-    assert rootless_fixer(dedent(xml)).splitlines() == [
-        "<__ROOTLESS__>",
-        "<a>Hello World</a>",
-        "<a>Goodbye</a>",
-        "</__ROOTLESS__>",
-    ]
-
-
 def test_rads_fixer():
     xml = """\
     <?xml version="1.0"?>
@@ -115,12 +102,40 @@ def test_rads_fixer():
     ]
 
 
+def test_rootless_fixer():
+    xml = """\
+    <a>Hello World</a>
+    <a>Goodbye</a>
+    """
+    assert rootless_fixer(dedent(xml)).splitlines() == [
+        "<__ROOTLESS__>",
+        "<a>Hello World</a>",
+        "<a>Goodbye</a>",
+        "</__ROOTLESS__>",
+    ]
+
+
 def test_rootless_fixer_with_empty_file():
     xml = """\
     <?xml version="1.0"?>
     <!-- This is an empty rootless XML file-->
     """
-    assert rootless_fixer(dedent(xml)).splitlines() == dedent(xml).splitlines()
+    assert rootless_fixer(dedent(xml)).splitlines() == [
+        '<?xml version="1.0"?>',
+        "<__ROOTLESS__>",
+        "<!-- This is an empty rootless XML file-->",
+        "</__ROOTLESS__>",
+    ]
+    assert rootless_fixer(dedent(xml), preserve_empty=False).splitlines() == [
+        '<?xml version="1.0"?>',
+        "<__ROOTLESS__>",
+        "<!-- This is an empty rootless XML file-->",
+        "</__ROOTLESS__>",
+    ]
+    assert (
+        rootless_fixer(dedent(xml), preserve_empty=True).splitlines()
+        == dedent(xml).splitlines()
+    )
 
 
 # NOTE: A full path file is used below since the API is allowed to expand to a


### PR DESCRIPTION
Skip empty configuration files instead of crashing.

The reason behind this is that some files such as `./config/pyrads/settings.xml` should be able to contain only comments in order to document the available options.