### PR TITLE
Add py.typed files as per PEP 561.

### DIFF
--- a/rads/py.typed
+++ b/rads/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561.

--- a/setup.py
+++ b/setup.py
@@ -239,6 +239,11 @@ setup(
     license="MIT",
     url="https://github.com/ccarocean/pyrads",
     packages=find_packages(),
+    package_data={
+        "rads": ["py.typed"],
+        "rads.config": ["py.typed"],
+        "rads.xml": ["py.typed"],
+    },
     python_requires=">=3.6",
     install_requires=install_requires,
     extras_require={


### PR DESCRIPTION
This adds `py.typed` files to the distributed packages as per [PEP 561](https://www.python.org/dev/peps/pep-0561/).