### PR TITLE
Use invoke to replace custom commands in setup.py.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
     - python: 3.7
       env: TOXENV=py37-lxml
     - python: 3.7
-      env: TOXENV=quality
+      env: TOXENV=checks
     - python: 3.7
       env: TOXENV=docs-html
     - python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,23 +6,32 @@ install:
 script: tox
 matrix:
   include:
-    - python: 3.6
+    - name: run test suite with python 3.6
+      python: 3.6
       env: TOXENV=py36
-    - python: 3.6
+    - name: run test suite with python 3.6 (using lxml)
+      python: 3.6
       env: TOXENV=py36-lxml
-    - python: 3.7
+    - name: run test suite with python 3.7
+      python: 3.7
       env: TOXENV=py37
-    - python: 3.7
+    - name: run test suite with python 3.7 (using lxml)
+      python: 3.7
       env: TOXENV=py37-lxml
-    - python: 3.7
+    - name: typing and style checks
+      python: 3.7
       env: TOXENV=checks
-    - python: 3.7
+    - name: test documentation build
+      python: 3.7
       env: TOXENV=docs-html
-    - python: 3.7
+    - name: test install and import
+      python: 3.7
       env: TOXENV=install
-    - python: 3.7
+    - name: test install and import (using lxml)
+      python: 3.7
       env: TOXENV=install-lxml
-    - python: 3.7
+    - name: generate report for codecov.io
+      python: 3.7
       install:
         - pip install tox codecov
       after_success:

--- a/README.rst
+++ b/README.rst
@@ -93,87 +93,41 @@ documentation.
 Development
 -----------
 
-The simplest way to get started working on PyRADS is:
+invoke_
+^^^^^^^
 
-.. code-block:: bash
-
-    git pull git@github.com:ccarocean/pyrads.git
-    cd pyrads
-    python3 -m venv --prompt PyRADS .venv
-    source .venv/bin/activate
-    pip install --upgrade pip setuptools wheel
-    pip install -e ".[dev]"
-
-*Naturally, you should fork the repository first.*
-
-If you are working on a system where libxml2_ is installed you may wish to replace the last command with:
-
-.. code-block:: bash
-
-    pip install -e ".[lxml,dev]"
-
-This will provide for faster XML parsing and more importantly better error messages.
-
-setup.py commands
-^^^^^^^^^^^^^^^^^
-
-PyRADS uses custom :code:`setup.py` commands to ease development.
-
-To run all quality checks simply use:
-
-.. code-block:: bash
-
-    python setup.py quality
-
-To run isort_ and black_ before the quality checks (recommended) use
-
-.. code-block:: bash
-
-    python setup.py quality --format
-
-To run all tests:
-
-.. code-block:: bash
-
-    python setup.py test
-
-or with coverage reports:
-
-.. code-block:: bash
-
-    python setup.py test --coverage
-
-To build source and wheel distributions (and check them):
+PyRADS uses invoke_ to make common development tasks easier.  For example the simplest way to get started working on PyRADS is to fork and clone the repository and then from within the main project directory:
 
 .. code-block::
 
-    python setup.py dist
+    pip install invoke && invoke develop
 
-To build the HTML documentation:
+This will install all development requirements with :code:`pip` and thus it is recommended to do this from a :code:`virtualenv`.
 
-.. code-block::
+If you are working on a system where libxml2_ is installed you may wish to also install lxml_ to provide faster XML parsing, but more importantly better error messages.  With lxml_, configuration parsing errors will be identified by line number.
 
-    python setup.py docs
-    # located at docs/_build/html/index.html
-
-or the PDF documentation (requires XeTeX_, xindy_, and latexmk_):
+To get the full list tasks that can be run by invoke_:
 
 .. code-block::
 
-    python setup.py docs --pdf
-    # located at docs/_build/latex/PyRADS.pdf
+    invoke -l
 
-Finally, to cleanup temporary files:
+For example, to run the formatters (isort_ and black_), static checkers, and
+all tests (with coverage report):
 
 .. code-block::
 
-    python setup.py cleanup
+    invoke format check test --coverage
+
+*NOTE: This should be ran before making any commits.*
+
+If on a non UNIX environment some of the tasks may fail.  If this happens you can use the :code:`--dry` flag to print out the commands that would be ran and then adjust accordingly.
 
 
-tox
-^^^
+tox_
+^^^^
 
-While the above :code:`setup.py` commands are relatively quick and are good for development they are insufficient to ensure PyRADS is working properly across all options (lxml or not) and all supported Python versions.  For this a tox configuration is provided.  To run the full test suite simply run:
+While the above invoke_ tasks are relatively quick and are good for development they are insufficient to ensure PyRADS is working properly across all options (lxml_ or not) and all supported Python versions.  For this a tox_ configuration is provided.  To run the full test suite simply run:
 
 .. code-block::
 
@@ -187,14 +141,17 @@ Or if you have a recent version of :code:`tox` you can speed up the process with
 
 The :code:`doc-pdf` environment will fail if XeTeX_, xindy_, and latexmk_.  This is usually fine.
 
-If all tests run by tox succeed the TravisCI build should succeed as well.
+If all tests run by tox succeed (except for :code:`doc-pdf`) the TravisCI build should succeed as well.
 
 
 .. _Radar Altimeter Database System: https://github.com/remkos/rads
 .. _RADS User Manual: https://github.com/remkos/rads/blob/master/doc/manuals/rads4_user_manual.pdf
 .. _libxml2: http://www.xmlsoft.org/
+.. _lxml: https://lxml.de/
+.. _invoke: http://www.pyinvoke.org/
 .. _isort: https://github.com/timothycrosley/isort
 .. _black: https://black.readthedocs.io/en/stable/
+.. _tox: https://tox.readthedocs.io/en/latest/
 .. _XeTeX: http://xetex.sourceforge.net/
 .. _xindy: http://xindy.sourceforge.net/
 .. _latexmk: https://mg.readthedocs.io/latexmk.html

--- a/README.rst
+++ b/README.rst
@@ -121,6 +121,8 @@ all tests (with coverage report):
 
 *NOTE: This should be ran before making any commits.*
 
+The classic :code:`python setup.py test` is supported as well but only runs the unit tests.
+
 If on a non UNIX environment some of the tasks may fail.  If this happens you can use the :code:`--dry` flag to print out the commands that would be ran and then adjust accordingly.
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[aliases]
+test = pytest
+
 [bdisk_wheel]
 universal=1
 

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,17 @@ def read(filename):
     return text
 
 
+# These are separated in order to always use the minimum packages for each.
+# This reduces the possibility of missing errors due to having a package
+# installed that will not be installed when deployed.
+docs_require = ["sphinx>=1.7", "sphinxcontrib-apidoc"]
+checks_require = ["flake8>=3.7.7", "mypy", "pydocstyle", "typing-extensions"]
+tests_require = ["pytest", "pytest-cov", "pytest-mock"]
+dev_requires = ["black", "isort", "twine"]
+
 if os.environ.get("READTHEDOCS") == "True":
     install_requires = ["dataclass_builder", "dataclasses;python_version=='3.6'"]
+    # install_requires += docs_require
 else:
     install_requires = [
         "appdirs",
@@ -37,18 +46,6 @@ else:
         "wrapt",
         "yzal",
     ]
-
-docs_require = ["sphinx>=1.7", "sphinxcontrib-apidoc"]
-tests_require = [
-    "flake8>=3.7.7",
-    "mypy",
-    "pydocstyle",
-    "pytest",
-    "pytest-cov",
-    "pytest-mock",
-    "pyflakes>=2.1.0",
-    "typing-extensions",
-]
 
 setup(
     name="rads",
@@ -67,12 +64,14 @@ setup(
         "rads.xml": ["py.typed"],
     },
     python_requires=">=3.6",
+    setup_requires=["pytest-runner"],
     install_requires=install_requires,
     extras_require={
         "lxml": ["lxml"],  # use libxml2 to read configuration files
-        "docs": docs_require,
+        "checks": checks_require,
         "tests": tests_require,
-        "dev": docs_require + tests_require + ["black", "isort", "twine"],
+        "docs": docs_require,
+        "dev": dev_requires + checks_require + tests_require + docs_require,
     },
     tests_require=tests_require,
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,11 @@
 import os
 import re
-import sys
 from pathlib import Path
-from subprocess import CalledProcessError, run
 
-from setuptools import Command, find_packages, setup
+from setuptools import find_packages, setup
 
 _SETUP = Path(__file__)
 _PROJECT = _SETUP.parent
-_DOCS = _PROJECT / "docs"
-_PACKAGE = _PROJECT / "rads"
-_TESTS = _PROJECT / "tests"
 
 
 def read_version(filename):
@@ -23,172 +18,6 @@ def read(filename):
     with open(_PROJECT / filename) as infile:
         text = infile.read()
     return text
-
-
-class Quality(Command):
-
-    description = "run code quality checkers"
-    user_options = [("format", "f", "run isort+black before QA")]
-
-    def initialize_options(self):
-        self.format = False
-
-    def finalize_options(self):
-        self.format = bool(self.format)
-
-    def run(self):
-        try:
-            if self.format:
-                run(["isort", "-rc", _PROJECT], check=True)
-                run(["black", _PROJECT], check=True)
-            run(["mypy", _PACKAGE], check=True)
-            run(["mypy", "--config-file", _TESTS / "mypy.ini", _TESTS], check=True)
-            run(["flake8", _SETUP, _PACKAGE, _TESTS], check=True)
-            run(["pydocstyle", _PACKAGE], check=True)
-        except CalledProcessError as err:
-            print("\n💀 Quality analysis failed 💀")
-            sys.exit(err.returncode)
-        print("\n✨ Quality analysis complete ✨")
-
-
-class Test(Command):
-
-    description = "run tests"
-    user_options = [("coverage", "c", "generate test coverage report")]
-
-    def initialize_options(self):
-        self.coverage = False
-
-    def finalize_options(self):
-        self.verbose = int(self.verbose)
-        self.coverage = bool(self.coverage)
-
-    def run(self):
-        pytest_args = ["pytest"]
-        if self.verbose >= 1:
-            pytest_args.append("-" + ("v" * self.verbose))
-        if self.coverage:
-            pytest_args.extend(["--cov", _PACKAGE, "--cov-branch"])
-        try:
-            run(pytest_args, check=True)
-            if self.coverage:
-                run(["coverage", "html"], check=True)
-        except CalledProcessError as err:
-            print("\n💀 Testing failed 💀")
-            sys.exit(err.returncode)
-        print("\n✨ Testing complete ✨")
-
-
-class Dist(Command):
-
-    description = "build source and wheel distributions"
-    user_options = []
-
-    def initialize_options(self):
-        pass
-
-    def finalize_options(self):
-        pass
-
-    def run(self):
-        try:
-            run(["python", _SETUP, "sdist"], check=True)
-            run(["python", _SETUP, "bdist_wheel"], check=True)
-            run(["twine", "check", _PROJECT / "dist/*"], check=True)
-        except CalledProcessError as err:
-            print("\n💀 Build failed 💀")
-            sys.exit(err.returncode)
-        print("\n✨ Build complete ✨")
-
-
-class Doc(Command):
-
-    description = "build documentation"
-    user_options = [("pdf", None, "Build PDF instead of HTML documentation.")]
-
-    def initialize_options(self):
-        self.pdf = False
-
-    def finalize_options(self):
-        self.pdf = bool(self.pdf)
-
-    def run(self):
-        try:
-            if self.pdf:
-                run(
-                    ["sphinx-build", "-M", "latexpdf", _DOCS, _DOCS / "_build"],
-                    check=True,
-                )
-            else:
-                run(
-                    ["sphinx-build", "-b", "html", _DOCS, _DOCS / "_build" / "html"],
-                    check=True,
-                )
-        except CalledProcessError as err:
-            print("\n💀 Documentation build failed 💀")
-            sys.exit(err.returncode)
-        print("\n✨ Documentation build complete ✨")
-
-
-class Cleanup(Command):
-
-    description = "cleanup temporary files"
-    user_options = []
-
-    def initialize_options(self):
-        pass
-
-    def finalize_options(self):
-        pass
-
-    @staticmethod
-    def remove(path):
-        if path.is_file():
-            print(f"removing {path}")
-            path.unlink()
-        if path.is_dir():
-            for file in path.iterdir():
-                Cleanup.remove(file)
-            path.rmdir()
-            print(f"removing {path}")
-
-    @staticmethod  # noqa: C901
-    def remove_matching(matcher, files=False, dirs=False):
-        for file in _PROJECT.iterdir():
-            if files and file.is_file() and matcher(file):
-                Cleanup.remove(file)
-            if dirs and file.is_dir() and matcher(file):
-                Cleanup.remove(file)
-
-        for dir in ["rads", "tests"]:
-            for root, dirs_, files_ in os.walk(_PROJECT / dir):
-                if files:
-                    for file in [Path(root) / f for f in files_]:
-                        if matcher(file):
-                            Cleanup.remove(file)
-                if dirs:
-                    for dir in [Path(root) / f for f in dirs_]:
-                        if matcher(dir):
-                            Cleanup.remove(dir)
-
-    def run(self):
-        try:
-            for file in (_DOCS / "api" / "apidoc").iterdir():
-                if file.is_file() and file.suffix == ".rst":
-                    self.remove(file)
-            self.remove(_DOCS / "_build")
-            self.remove(_PROJECT / "dist")
-            self.remove(_PROJECT / "build")
-            self.remove_matching(lambda f: f.suffix == ".pyc", files=True)
-            self.remove_matching(lambda f: f.name == ".coverage", files=True)
-            self.remove_matching(lambda f: f.name == ".pytest_cache", dirs=True)
-            self.remove_matching(lambda f: f.name == ".mypy_cache", dirs=True)
-            self.remove_matching(lambda f: f.name == "htmlcov", dirs=True)
-            self.remove_matching(lambda f: f.suffix == ".egg-info", dirs=True)
-        except Exception:
-            print("\n💀 Documentation build failed 💀")
-            sys.exit(1)
-        print("\n✨ Cleanup complete ✨")
 
 
 if os.environ.get("READTHEDOCS") == "True":
@@ -222,13 +51,6 @@ tests_require = [
 ]
 
 setup(
-    cmdclass={
-        "quality": Quality,
-        "test": Test,
-        "dist": Dist,
-        "doc": Doc,
-        "cleanup": Cleanup,
-    },
     name="rads",
     version=read_version("rads/__version__.py"),
     author="Michael R. Shannon",

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,149 @@
+import os
+
+from invoke import Collection, task
+from invoke.exceptions import Exit
+
+PACKAGE = "rads"
+
+
+@task
+def check_typing(c):
+    """check typing"""
+    c.run("mypy rads")
+    c.run("mypy --config-file tests/mypy.ini tests")
+
+
+@task
+def check_style(c):
+    """check code style"""
+    c.run("flake8 setup.py tasks.py rads tests")
+
+
+@task
+def check_docstrings(c):
+    """check docstrings"""
+    c.run("pydocstyle rads")
+
+
+@task(check_typing, check_style, check_docstrings)
+def check_all(c):
+    """run all static checkers"""
+
+
+@task(help={"lxml": "use libxml2 for XML loading"})
+def develop(c, lxml=False):
+    """install development dependencies"""
+    lxml_ = ",lxml" if lxml else ""
+    c.run(f'pip install --upgrade -e ".[dev{lxml_}]"')
+
+
+@task
+def dist_clean(c):
+    """cleanup dists"""
+    c.run("rm -rf dist")
+    c.run("rm -rf build")
+
+
+@task(dist_clean)
+def dist_build(c):
+    """build and check source and wheel dists"""
+    c.run("python setup.py sdist")
+    c.run("python setup.py bdist_wheel")
+    c.run("twine check dist/*")
+
+
+@task(help={"format": "format to build: html (default) or pdf"})
+def doc_build(c, format="html"):
+    """build documentation"""
+    format = format.lower().strip()
+    if format == "html":
+        c.run("sphinx-build -b html docs docs/_build/html")
+    elif format == "pdf":
+        c.run("sphinx-build -M latexpdf docs docs/_build")
+    else:
+        raise Exit(f"invalid documentation format '{format}'")
+
+
+@task
+def doc_clean(c):
+    """clean built documentation"""
+    c.run("rm -rf docs/_build")
+    c.run("rm -f docs/api/apidoc/*.rst")
+
+
+@task
+def format_isort(c):
+    """sort imports"""
+    c.run("isort -rc .")
+
+
+@task
+def format_black(c):
+    """format the codebase with black"""
+    c.run("black .")
+
+
+@task(format_isort, format_black)
+def format_all(c):
+    """isort + black."""
+
+
+@task(
+    incrementable=["verbose"],
+    help={
+        "verbose": "enable verbose output, can be repeated up to 2 times",
+        "coverage": "generate a coverage report",
+        "html": "generate an HTML coverage report",
+    },
+)
+def test(c, verbose=0, coverage=False, html=False):
+    """run unit tests."""
+    verbose_ = "-" + "v" * verbose if verbose > 0 else ""
+    coverage_ = f"--cov {PACKAGE} --cov-branch" if coverage or html else ""
+    c.run(f"pytest {verbose_} {coverage_}")
+    if html:
+        c.run("coverage html")
+
+
+@task(doc_clean, dist_clean)
+def clean(c):
+    """cleanup everything"""
+    c.run("rm -f .coverage")
+    c.run("rm -rf htmlcov")
+    c.run("rm -rf .pytest_cache")
+    c.run("rm -rf .mypy_cache")
+    c.run("rm -rf *.egg-info")
+    for top_dir in ["rads", "tests"]:
+        for root, dirs, files in os.walk(top_dir):
+            for dir in dirs:
+                if dir == "__pycache__":
+                    c.run(f"rm -rf {os.path.join(root, dir)}")
+
+
+check = Collection("check")
+check.add_task(check_all, "all", default=True)
+check.add_task(check_typing, "typing")
+check.add_task(check_style, "style")
+check.add_task(check_docstrings, "docstrings")
+
+dist = Collection("dist")
+dist.add_task(dist_build, "build", default=True)
+dist.add_task(dist_clean, "clean")
+
+doc = Collection("doc")
+doc.add_task(doc_build, "build", default=True)
+doc.add_task(doc_clean, "clean")
+
+format = Collection("format")
+format.add_task(format_all, "all", default=True)
+format.add_task(format_isort, "isort")
+format.add_task(format_black, "black")
+
+ns = Collection()
+ns.add_task(clean)
+ns.add_task(develop)
+ns.add_task(test)
+ns.add_collection(check)
+ns.add_collection(dist)
+ns.add_collection(doc)
+ns.add_collection(format)

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,13 @@
 [tox]
+minversion = 3.4.0
 basepython = python3.7
 skip_missing_interpreters = true
 envlist = {py36,py37}{,-lxml},quality,docs-{html,pdf},install{,-lxml},coverage
 
 [testenv]
 extras = tests
-commands = python setup.py test -q
+deps = invoke
+commands = invoke {tty:--pty:} test
 
 [testenv:py36-lxml]
 extras =
@@ -16,23 +18,26 @@ extras =
 extras = {[testenv:py36-lxml]extras}
 
 [testenv:quality]
-commands = python setup.py quality
+commands = invoke {tty:--pty:} check
 
 [testenv:docs-html]
 extras = docs
-commands = python setup.py doc
+commands = invoke {tty:--pty:} doc
 
 [testenv:docs-pdf]
 extras = docs
-commands = python setup.py doc --pdf
+ignore_outcome = true
+commands = invoke {tty:--pty:} doc --format pdf
 
 [testenv:install]
+deps =
 skip_install = true
 commands = pip install .
 
 [testenv:install-lxml]
-skip_install = true
+deps = {[testenv:install]deps}
+skip_install = {[testenv:install]skip_install}
 commands = pip install .[lxml]
 
 [testenv:coverage]
-commands = python setup.py test -q --coverage
+commands = invoke {tty:--pty:} test --coverage

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 minversion = 3.4.0
 basepython = python3.7
 skip_missing_interpreters = true
-envlist = {py36,py37}{,-lxml},quality,docs-{html,pdf},install{,-lxml},coverage
+envlist = {py36,py37}{,-lxml},checks,docs-{html,pdf},install{,-lxml},coverage
 
 [testenv]
 extras = tests
@@ -17,8 +17,10 @@ extras =
 [testenv:py37-lxml]
 extras = {[testenv:py36-lxml]extras}
 
-[testenv:quality]
-commands = invoke {tty:--pty:} check
+[testenv:checks]
+extras = checks
+commands =
+    invoke {tty:--pty:} check
 
 [testenv:docs-html]
 extras = docs


### PR DESCRIPTION
Move custom commands out of `setup.py` to reduce clutter not related to the package and it's dependencies.