### PR TITLE
Load file like objects as well as file paths.

### DIFF
--- a/rads/__init__.py
+++ b/rads/__init__.py
@@ -2,8 +2,8 @@
 
 from .__version__ import __version__
 from .config.loader import config_files, get_dataroot, load_config
-from .exceptions import RADSError, ConfigError, InvalidDataroot
 from .constants import EPOCH
+from .exceptions import ConfigError, InvalidDataroot, RADSError
 
 __all__ = [
     "__version__",

--- a/rads/config/tree.py
+++ b/rads/config/tree.py
@@ -24,7 +24,7 @@ import numpy as np  # type: ignore
 from cf_units import Unit  # type: ignore
 
 from ..rpn import CompleteExpression
-from ..typing import IntOrArray, Number, NumberOrArray, PathLike
+from ..typing import IntOrArray, Number, NumberOrArray, PathLike, PathLikeOrFile
 
 __all__ = [
     "PreConfig",
@@ -60,7 +60,7 @@ class PreConfig:
 
     dataroot: PathLike
     """The location of the RADS data root."""
-    config_files: Sequence[PathLike]
+    config_files: Sequence[PathLikeOrFile]
     """
     XML configuration files used to load this pre-config. Also the XML files to
     use when loading the main PyRADS configuration.
@@ -592,7 +592,7 @@ class Config:
 
     dataroot: PathLike
     """Path to the RADS data root."""
-    config_files: Sequence[PathLike]
+    config_files: Sequence[PathLikeOrFile]
     """Paths to the XML configuration files used to load this configuration.
 
     *The order is the same as they were loaded.*

--- a/rads/typing.py
+++ b/rads/typing.py
@@ -5,14 +5,23 @@ from typing import IO, TYPE_CHECKING, Any, Union
 
 import numpy as np  # type: ignore
 
-__all__ = ["PathLike", "PathOrFile", "Number", "IntOrArray", "NumberOrArray"]
+__all__ = [
+    "PathLike",
+    "PathLikeOrFile",
+    "PathOrFile",
+    "Number",
+    "IntOrArray",
+    "NumberOrArray",
+]
 
 if TYPE_CHECKING:
     PathLike = Union[str, os.PathLike[str]]
+    PathOrFile = Union[os.PathLike[str], IO[Any]]
 else:
     PathLike = Union[str, os.PathLike]
+    PathOrFile = Union[os.PathLike, IO[Any]]
 
-PathOrFile = Union[PathLike, IO[Any], int]
+PathLikeOrFile = Union[PathLike, IO[Any]]
 
 # for the purpose of PyRADS bool as a number since it will act
 # as 0 or 1 when used as a number

--- a/rads/utility.py
+++ b/rads/utility.py
@@ -5,7 +5,7 @@ from typing import IO, Any, List, Optional, Union, cast
 
 from wrapt import ObjectProxy  # type: ignore
 
-from .typing import PathLike, PathOrFile
+from .typing import PathLike, PathLikeOrFile
 
 __all__ = [
     "ensure_open",
@@ -27,7 +27,7 @@ class _NoCloseIOWrapper(ObjectProxy):  # type: ignore
 
 
 def ensure_open(
-    file: PathOrFile,
+    file: PathLikeOrFile,
     mode: str = "r",
     buffering: int = -1,
     encoding: Optional[str] = None,
@@ -96,8 +96,8 @@ def ensure_open(
     )
 
 
-def filestring(file: PathOrFile) -> Optional[str]:
-    """Convert a PathOrFile to a string.
+def filestring(file: PathLikeOrFile) -> Optional[str]:
+    """Convert a PathLikeOrFile to a string.
 
     :param file:
         file or file-like object to get the string for.

--- a/rads/utility.py
+++ b/rads/utility.py
@@ -1,5 +1,6 @@
 """Utility functions."""
 
+import io
 import os
 from typing import IO, Any, List, Optional, Union, cast
 
@@ -10,6 +11,7 @@ from .typing import PathLike, PathLikeOrFile
 __all__ = [
     "ensure_open",
     "filestring",
+    "isio",
     "xor",
     "contains_sublist",
     "merge_sublist",
@@ -124,6 +126,32 @@ def filestring(file: PathLikeOrFile) -> Optional[str]:
         except UnicodeDecodeError:
             return None
     raise TypeError(f"'{type(file)}' is not a file like object")
+
+
+def isio(obj: Any, *, read: bool = False, write: bool = False) -> bool:
+    """Determine if object is IO like and is read and/or write.
+
+    .. note::
+
+        Falls back to :code:`isinstnace(obj, io.IOBase)` if neither `read` nor
+        `write` is True.
+
+    :param obj:
+        Object to check if it is an IO like object.
+    :param read:
+        Require `obj` to be readable if True.
+    :param write:
+        Require `obj` to be writable if True.
+
+    :return:
+        True if the given `obj` is readable and/or writeable as defined by the
+        `read` and `write` arguments.
+    """
+    if read or write:
+        return (not read or hasattr(obj, "read")) and (
+            not write or hasattr(obj, "write")
+        )
+    return isinstance(obj, io.IOBase)
 
 
 def xor(a: bool, b: bool) -> bool:

--- a/rads/utility.py
+++ b/rads/utility.py
@@ -82,7 +82,7 @@ def ensure_open(
     .. seealso:: :func:`open`
     """
     if hasattr(file, "read"):
-        if closeio:
+        if not closeio:
             return cast(IO[Any], _NoCloseIOWrapper(file))
         return cast(IO[Any], file)
     return open(

--- a/rads/xml/utility.py
+++ b/rads/xml/utility.py
@@ -5,7 +5,7 @@ import re
 from itertools import chain, dropwhile, takewhile, tee
 from typing import Any, Callable, Optional, Sequence, cast
 
-from ..typing import PathLike, PathOrFile
+from ..typing import PathLike, PathLikeOrFile
 from ..utility import ensure_open, filestring
 
 try:
@@ -29,7 +29,7 @@ __all__ = [
 
 
 # TODO: Remove when ElementTree.parse accepts PathLike objects.
-def _fix_source(source: PathOrFile) -> Any:
+def _fix_source(source: PathLikeOrFile) -> Any:
     if isinstance(source, int):
         return source
     if hasattr(source, "read"):
@@ -38,7 +38,7 @@ def _fix_source(source: PathOrFile) -> Any:
 
 
 def parse(
-    source: PathOrFile,
+    source: PathLikeOrFile,
     parser: Optional[xml.XMLParser] = None,
     fixer: Optional[Callable[[str], str]] = None,
 ) -> xml.Element:

--- a/rads/xml/utility.py
+++ b/rads/xml/utility.py
@@ -6,7 +6,7 @@ from itertools import chain, dropwhile, takewhile, tee
 from typing import Any, Callable, Optional, Sequence, cast
 
 from ..typing import PathLike, PathLikeOrFile
-from ..utility import ensure_open, filestring
+from ..utility import ensure_open, filestring, isio
 
 try:
     from ..xml import lxml as xml
@@ -30,9 +30,7 @@ __all__ = [
 
 # TODO: Remove when ElementTree.parse accepts PathLike objects.
 def _fix_source(source: PathLikeOrFile) -> Any:
-    if isinstance(source, int):
-        return source
-    if hasattr(source, "read"):
+    if isio(source, read=True):
         return source
     return os.fspath(cast(PathLike, source))
 

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -1,12 +1,34 @@
+import io
 import pytest  # type: ignore
 
 from rads.utility import (
+    ensure_open,
     contains_sublist,
     delete_sublist,
     fortran_float,
     merge_sublist,
     xor,
 )
+
+
+def test_ensure_open_closeio_default():
+    file = io.StringIO("contents")
+    with ensure_open(file) as f:
+        assert not f.closed
+    assert not f.closed
+
+def test_ensure_open_closeio_true():
+    file = io.StringIO("contents")
+    with ensure_open(file, closeio=True) as f:
+        assert not f.closed
+    assert f.closed
+
+
+def test_ensure_open_closeio_false():
+    file = io.StringIO("contents")
+    with ensure_open(file, closeio=False) as f:
+        assert not f.closed
+    assert not f.closed
 
 
 def test_xor():

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -1,34 +1,67 @@
 import io
+
 import pytest  # type: ignore
 
 from rads.utility import (
-    ensure_open,
     contains_sublist,
     delete_sublist,
+    ensure_open,
     fortran_float,
+    isio,
     merge_sublist,
     xor,
 )
 
 
 def test_ensure_open_closeio_default():
-    file = io.StringIO("contents")
+    file = io.StringIO("content")
     with ensure_open(file) as f:
         assert not f.closed
     assert not f.closed
 
+
 def test_ensure_open_closeio_true():
-    file = io.StringIO("contents")
+    file = io.StringIO("content")
     with ensure_open(file, closeio=True) as f:
         assert not f.closed
     assert f.closed
 
 
 def test_ensure_open_closeio_false():
-    file = io.StringIO("contents")
+    file = io.StringIO("content")
     with ensure_open(file, closeio=False) as f:
         assert not f.closed
     assert not f.closed
+
+
+def test_isio(mocker):
+    assert isio(io.StringIO("content"))
+    assert not isio("string is not io")
+    m = mocker.Mock()
+    m.read.return_value = "duck typing not accepted"
+    assert not isio(m)
+
+
+def test_isio_read(mocker):
+    assert isio(io.StringIO("content"), read=True)
+    assert not isio("string is not io", read=True)
+    m = mocker.Mock(spec=["read"])
+    m.read.return_value = "duck typing is accepted"
+    assert isio(m, read=True)
+    m = mocker.Mock(spec=["write"])
+    m.write.return_value = "duck typing is accepted"
+    assert not isio(m, read=True)
+
+
+def test_isio_write(mocker):
+    assert isio(io.StringIO("content"), write=True)
+    assert not isio("string is not io", write=True)
+    m = mocker.Mock(spec=["read"])
+    m.read.return_value = "duck typing is accepted"
+    assert not isio(m, write=True)
+    m = mocker.Mock(spec=["write"])
+    m.write.return_value = "duck typing is accepted"
+    assert isio(m, write=True)
 
 
 def test_xor():


### PR DESCRIPTION
Allow `rads.load_config` to accept file like objects as well as file paths.  This allows for greater flexibility, such as loading from configuration files that may not exist on the filesystem.