### PR TITLE
Update to remove unnecessary type ignore comments.

### DIFF
--- a/rads/xml/etree.py
+++ b/rads/xml/etree.py
@@ -133,13 +133,9 @@ def error_with_file(error: ParseError, file: str) -> ParseError:
         added.
     """
     error.filename = file
-    # TODO: Remove the type ignore's below when
-    #  https://github.com/python/typeshed/pull/3158 makes it into Mypy, also
-    #  update Mypy version as well.
     new_error = type(error)(
-        error.msg,
-        (file, error.position[0], error.position[1], error.text),  # type: ignore
+        error.msg, (file, error.position[0], error.position[1], error.text)
     )
-    new_error.code = error.code  # type: ignore
-    new_error.position = error.position  # type: ignore
+    new_error.code = error.code
+    new_error.position = error.position
     return new_error

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ docs_require = ["packaging", "sphinx>=1.7", "sphinxcontrib-apidoc"]
 checks_require = [
     "flake8>=3.7.7",
     "flake8-bugbear",
-    "mypy",
+    "mypy>=0.730",
     "pydocstyle",
     "typing-extensions",
 ]


### PR DESCRIPTION
Now that https://github.com/python/typeshed/pull/3158 has been included in Mypy the workaround is no longer needed.